### PR TITLE
Add CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+# TEB model version x.x.x (https://github.com/dmey/teb-model).
+# Copyright (c) 2018 D. Meyer.
+
+matrix:
+  include:
+    - language: python
+      os: linux
+      dist: xenial
+      python: "3.7"
+      sudo: false
+      env: BUILD_TYPE=Debug
+      addons:
+        apt:
+          packages:
+            - gfortran
+    - language: python
+      os: linux
+      dist: xenial
+      python: "3.7"
+      sudo: false
+      env: BUILD_TYPE=Release
+      addons:
+        apt:
+          packages:
+            - gfortran
+    - language: generic
+      os: osx
+      env: BUILD_TYPE=Debug
+    - language: generic
+      os: osx
+      env: BUILD_TYPE=Release
+
+before_install:
+  - if [[ $TRAVIS_OS_NAME == osx ]]; then brew update && brew install gcc && brew upgrade python; fi
+
+install:
+  - mkdir build && pushd build
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+  - cmake --build .
+  - popd
+
+script:
+  - pushd tests/CAPITOUL
+  - ../../build/driver
+  - popd

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Town Energy Balance (TEB)
+# Town Energy Balance (TEB) [![Build Status](https://travis-ci.com/dmey/teb-model.svg?token=3tqUbxqJuLtozjxqDymC&branch=master)](https://travis-ci.com/dmey/teb-model)
 
 ## Build instructions for Windows, Linux and macOS
 


### PR DESCRIPTION
Add CI support with limited testing. We only check that the model driver runs with inputs from the CAPITOUL case -- no comparison made at this stage.