### PR TITLE
Update software licence to CeCILL version 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # TEB version 4.0.0 (https://github.com/teb-model/teb).
-# Copyright 2018 D. Meyer. Licensed under CeCILL-C version 1.
+# Copyright 2018 D. Meyer. Licensed under CeCILL version 2.1.
 
 git:
   depth: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # TEB version 4.0.0 (https://github.com/teb-model/teb).
-# Copyright 2018 D. Meyer. Licensed under CeCILL-C version 1.
+# Copyright 2018 D. Meyer. Licensed under CeCILL version 2.1.
 
 cmake_minimum_required(VERSION 3.1)
 project(TEB Fortran)

--- a/Licence_CeCILL_V2.1-en.txt
+++ b/Licence_CeCILL_V2.1-en.txt
@@ -1,5 +1,7 @@
 
-CeCILL-C FREE SOFTWARE LICENSE AGREEMENT
+  CeCILL FREE SOFTWARE LICENSE AGREEMENT
+
+Version 2.1 dated 2013-06-21
 
 
     Notice
@@ -8,27 +10,27 @@ This Agreement is a Free Software license agreement that is the result
 of discussions between its authors in order to ensure compliance with
 the two main principles guiding its drafting:
 
-    * firstly, compliance with the principles governing the distribution
-      of Free Software: access to source code, broad rights granted to
-      users,
-    * secondly, the election of a governing law, French law, with which
-      it is conformant, both as regards the law of torts and
-      intellectual property law, and the protection that it offers to
-      both authors and holders of the economic rights over software.
+  * firstly, compliance with the principles governing the distribution
+    of Free Software: access to source code, broad rights granted to users,
+  * secondly, the election of a governing law, French law, with which it
+    is conformant, both as regards the law of torts and intellectual
+    property law, and the protection that it offers to both authors and
+    holders of the economic rights over software.
 
-The authors of the CeCILL-C (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre])
-license are:
+The authors of the CeCILL (for Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre]) 
+license are: 
 
-Commissariat à l'Energie Atomique - CEA, a public scientific, technical
-and industrial research establishment, having its principal place of
-business at 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris, France.
+Commissariat à l'énergie atomique et aux énergies alternatives - CEA, a
+public scientific, technical and industrial research establishment,
+having its principal place of business at 25 rue Leblanc, immeuble Le
+Ponant D, 75015 Paris, France.
 
 Centre National de la Recherche Scientifique - CNRS, a public scientific
 and technological establishment, having its principal place of business
 at 3 rue Michel-Ange, 75794 Paris cedex 16, France.
 
 Institut National de Recherche en Informatique et en Automatique -
-INRIA, a public scientific and technological establishment, having its
+Inria, a public scientific and technological establishment, having its
 principal place of business at Domaine de Voluceau, Rocquencourt, BP
 105, 78153 Le Chesnay cedex, France.
 
@@ -36,11 +38,11 @@ principal place of business at Domaine de Voluceau, Rocquencourt, BP
     Preamble
 
 The purpose of this Free Software license agreement is to grant users
-the right to modify and re-use the software governed by this license.
+the right to modify and redistribute the software governed by this
+license within the framework of an open source distribution model.
 
-The exercising of this right is conditional upon the obligation to make
-available to the community the modifications made to the source code of
-the software so as to contribute to its evolution.
+The exercising of this right is conditional upon certain obligations for
+users so as to preserve this status for all subsequent redistributions.
 
 In consideration of access to the source code and the rights to copy,
 modify and redistribute granted by the license, users are provided only
@@ -63,6 +65,10 @@ removed herefrom.
 This Agreement may apply to any or all software for which the holder of
 the economic rights decides to submit the use thereof to its provisions.
 
+Frequently asked questions can be found on the official website of the
+CeCILL licenses family (http://www.cecill.info/index.en.html) for any 
+necessary clarification.
+
 
     Article 1 - DEFINITIONS
 
@@ -81,7 +87,7 @@ Object Code form and, where applicable, its documentation, "as is" when
 it is first distributed under the terms and conditions of the Agreement.
 
 Modified Software: means the Software modified by at least one
-Integrated Contribution.
+Contribution.
 
 Source Code: means all the Software's instructions and program lines to
 which access is required so as to modify the Software.
@@ -94,23 +100,34 @@ Software.
 
 Licensee: means the Software user(s) having accepted the Agreement.
 
-Contributor: means a Licensee having made at least one Integrated
-Contribution.
+Contributor: means a Licensee having made at least one Contribution.
 
 Licensor: means the Holder, or any other individual or legal entity, who
 distributes the Software under the Agreement.
 
-Integrated Contribution: means any or all modifications, corrections,
-translations, adaptations and/or new functions integrated into the
-Source Code by any or all Contributors.
+Contribution: means any or all modifications, corrections, translations,
+adaptations and/or new functions integrated into the Software by any or
+all Contributors, as well as any or all Internal Modules.
 
-Related Module: means a set of sources files including their
-documentation that, without modification to the Source Code, enables
-supplementary functions or services in addition to those offered by the
-Software.
+Module: means a set of sources files including their documentation that
+enables supplementary functions or services in addition to those offered
+by the Software.
 
-Derivative Software: means any combination of the Software, modified or
-not, and of a Related Module.
+External Module: means any or all Modules, not derived from the
+Software, so that this Module and the Software run in separate address
+spaces, with one calling the other when they are run.
+
+Internal Module: means any or all Module, connected to the Software so
+that they both execute in the same address space.
+
+GNU GPL: means the GNU General Public License version 2 or any
+subsequent version, as published by the Free Software Foundation Inc.
+
+GNU Affero GPL: means the GNU Affero General Public License version 3 or
+any subsequent version, as published by the Free Software Foundation Inc.
+
+EUPL: means the European Union Public License version 1.1 or any
+subsequent version, as published by the European Commission.
 
 Parties: mean both the Licensee and the Licensor.
 
@@ -121,8 +138,8 @@ These expressions may be used both in singular and plural form.
 
 The purpose of the Agreement is the grant by the Licensor to the
 Licensee of a non-exclusive, transferable and worldwide license for the
-Software as set forth in Article 5 hereinafter for the whole term of the
-protection granted by the rights over said Software. 
+Software as set forth in Article 5 <#scope> hereinafter for the whole
+term of the protection granted by the rights over said Software.
 
 
     Article 3 - ACCEPTANCE
@@ -131,18 +148,17 @@ protection granted by the rights over said Software.
 conditions of this Agreement upon the occurrence of the first of the
 following events:
 
-    * (i) loading the Software by any or all means, notably, by
-      downloading from a remote server, or by loading from a physical
-      medium;
-    * (ii) the first time the Licensee exercises any of the rights
-      granted hereunder.
+  * (i) loading the Software by any or all means, notably, by
+    downloading from a remote server, or by loading from a physical medium;
+  * (ii) the first time the Licensee exercises any of the rights granted
+    hereunder.
 
 3.2 One copy of the Agreement, containing a notice relating to the
 characteristics of the Software, to the limited warranty, and to the
 fact that its use is restricted to experienced users has been provided
 to the Licensee prior to its acceptance as set forth in Article 3.1
-hereinabove, and the Licensee hereby acknowledges that it has read and
-understood it.
+<#accepting> hereinabove, and the Licensee hereby acknowledges that it
+has read and understood it.
 
 
     Article 4 - EFFECTIVE DATE AND TERM
@@ -151,7 +167,7 @@ understood it.
       4.1 EFFECTIVE DATE
 
 The Agreement shall become effective on the date when it is accepted by
-the Licensee as set forth in Article 3.1.
+the Licensee as set forth in Article 3.1 <#accepting>.
 
 
       4.2 TERM
@@ -181,30 +197,29 @@ The Licensee is authorized to use the Software, without any limitation
 as to its fields of application, with it being hereinafter specified
 that this comprises:
 
-   1. permanent or temporary reproduction of all or part of the Software
-      by any or all means and in any or all form.
+ 1. permanent or temporary reproduction of all or part of the Software
+    by any or all means and in any or all form.
 
-   2. loading, displaying, running, or storing the Software on any or
-      all medium.
+ 2. loading, displaying, running, or storing the Software on any or all
+    medium.
 
-   3. entitlement to observe, study or test its operation so as to
-      determine the ideas and principles behind any or all constituent
-      elements of said Software. This shall apply when the Licensee
-      carries out any or all loading, displaying, running, transmission
-      or storage operation as regards the Software, that it is entitled
-      to carry out hereunder.
+ 3. entitlement to observe, study or test its operation so as to
+    determine the ideas and principles behind any or all constituent
+    elements of said Software. This shall apply when the Licensee
+    carries out any or all loading, displaying, running, transmission or
+    storage operation as regards the Software, that it is entitled to
+    carry out hereunder.
 
 
-      5.2 RIGHT OF MODIFICATION
+      5.2 ENTITLEMENT TO MAKE CONTRIBUTIONS
 
-The right of modification includes the right to translate, adapt,
+The right to make Contributions includes the right to translate, adapt,
 arrange, or make any or all modifications to the Software, and the right
-to reproduce the resulting software. It includes, in particular, the
-right to create a Derivative Software.
+to reproduce the resulting software.
 
-The Licensee is authorized to make any or all modification to the
+The Licensee is authorized to make any or all Contributions to the
 Software provided that it includes an explicit notice that it is the
-author of said modification and indicates the date of the creation thereof.
+author of said Contribution and indicates the date of the creation thereof.
 
 
       5.3 RIGHT OF DISTRIBUTION
@@ -226,69 +241,62 @@ The Licensee is authorized to distribute true copies of the Software in
 Source Code or Object Code form, provided that said distribution
 complies with all the provisions of the Agreement and is accompanied by:
 
-   1. a copy of the Agreement,
+ 1. a copy of the Agreement,
 
-   2. a notice relating to the limitation of both the Licensor's
-      warranty and liability as set forth in Articles 8 and 9,
+ 2. a notice relating to the limitation of both the Licensor's warranty
+    and liability as set forth in Articles 8 and 9,
 
 and that, in the event that only the Object Code of the Software is
 redistributed, the Licensee allows effective access to the full Source
-Code of the Software at a minimum during the entire period of its
+Code of the Software for a period of at least three years from the
 distribution of the Software, it being understood that the additional
-cost of acquiring the Source Code shall not exceed the cost of
-transferring the data.
+acquisition cost of the Source Code shall not exceed the cost of the
+data transfer.
 
 
         5.3.2 DISTRIBUTION OF MODIFIED SOFTWARE
 
-When the Licensee makes an Integrated Contribution to the Software, the
-terms and conditions for the distribution of the resulting Modified
-Software become subject to all the provisions of this Agreement.
+When the Licensee makes a Contribution to the Software, the terms and
+conditions for the distribution of the resulting Modified Software
+become subject to all the provisions of this Agreement.
 
 The Licensee is authorized to distribute the Modified Software, in
 source code or object code form, provided that said distribution
 complies with all the provisions of the Agreement and is accompanied by:
 
-   1. a copy of the Agreement,
+ 1. a copy of the Agreement,
 
-   2. a notice relating to the limitation of both the Licensor's
-      warranty and liability as set forth in Articles 8 and 9,
+ 2. a notice relating to the limitation of both the Licensor's warranty
+    and liability as set forth in Articles 8 and 9,
 
-and that, in the event that only the object code of the Modified
-Software is redistributed, the Licensee allows effective access to the
-full source code of the Modified Software at a minimum during the entire
-period of its distribution of the Modified Software, it being understood
-that the additional cost of acquiring the source code shall not exceed
-the cost of transferring the data.
+and, in the event that only the object code of the Modified Software is
+redistributed,
 
-
-        5.3.3 DISTRIBUTION OF DERIVATIVE SOFTWARE
-
-When the Licensee creates Derivative Software, this Derivative Software
-may be distributed under a license agreement other than this Agreement,
-subject to compliance with the requirement to include a notice
-concerning the rights over the Software as defined in Article 6.4.
-In the event the creation of the Derivative Software required modification 
-of the Source Code, the Licensee undertakes that:
-
-   1. the resulting Modified Software will be governed by this Agreement,
-   2. the Integrated Contributions in the resulting Modified Software
-      will be clearly identified and documented,
-   3. the Licensee will allow effective access to the source code of the
-      Modified Software, at a minimum during the entire period of
-      distribution of the Derivative Software, such that such
-      modifications may be carried over in a subsequent version of the
-      Software; it being understood that the additional cost of
-      purchasing the source code of the Modified Software shall not
-      exceed the cost of transferring the data.
+ 3. a note stating the conditions of effective access to the full source
+    code of the Modified Software for a period of at least three years
+    from the distribution of the Modified Software, it being understood
+    that the additional acquisition cost of the source code shall not
+    exceed the cost of the data transfer.
 
 
-        5.3.4 COMPATIBILITY WITH THE CeCILL LICENSE
+        5.3.3 DISTRIBUTION OF EXTERNAL MODULES
 
-When a Modified Software contains an Integrated Contribution subject to
-the CeCILL license agreement, or when a Derivative Software contains a
-Related Module subject to the CeCILL license agreement, the provisions
-set forth in the third item of Article 6.4 are optional.
+When the Licensee has developed an External Module, the terms and
+conditions of this Agreement do not apply to said External Module, that
+may be distributed under a separate license agreement.
+
+
+        5.3.4 COMPATIBILITY WITH OTHER LICENSES
+
+The Licensee can include a code that is subject to the provisions of one
+of the versions of the GNU GPL, GNU Affero GPL and/or EUPL in the
+Modified or unmodified Software, and distribute that entire code under
+the terms of the same version of the GNU GPL, GNU Affero GPL and/or EUPL.
+
+The Licensee can include the Modified or unmodified Software in a code
+that is subject to the provisions of one of the versions of the GNU GPL,
+GNU Affero GPL and/or EUPL and distribute that entire code under the
+terms of the same version of the GNU GPL, GNU Affero GPL and/or EUPL.
 
 
     Article 6 - INTELLECTUAL PROPERTY
@@ -303,44 +311,39 @@ and no one shall be entitled to modify the terms and conditions for the
 distribution of said Initial Software.
 
 The Holder undertakes that the Initial Software will remain ruled at
-least by this Agreement, for the duration set forth in Article 4.2.
+least by this Agreement, for the duration set forth in Article 4.2 <#term>.
 
 
-      6.2 OVER THE INTEGRATED CONTRIBUTIONS
+      6.2 OVER THE CONTRIBUTIONS
 
-The Licensee who develops an Integrated Contribution is the owner of the
+The Licensee who develops a Contribution is the owner of the
 intellectual property rights over this Contribution as defined by
 applicable law.
 
 
-      6.3 OVER THE RELATED MODULES
+      6.3 OVER THE EXTERNAL MODULES
 
-The Licensee who develops a Related Module is the owner of the
-intellectual property rights over this Related Module as defined by
+The Licensee who develops an External Module is the owner of the
+intellectual property rights over this External Module as defined by
 applicable law and is free to choose the type of agreement that shall
-govern its distribution under the conditions defined in Article 5.3.3.
+govern its distribution.
 
 
-      6.4 NOTICE OF RIGHTS
+      6.4 JOINT PROVISIONS
 
 The Licensee expressly undertakes:
 
-   1. not to remove, or modify, in any manner, the intellectual property
-      notices attached to the Software;
+ 1. not to remove, or modify, in any manner, the intellectual property
+    notices attached to the Software;
 
-   2. to reproduce said notices, in an identical manner, in the copies
-      of the Software modified or not;
-
-   3. to ensure that use of the Software, its intellectual property
-      notices and the fact that it is governed by the Agreement is
-      indicated in a text that is easily accessible, specifically from
-      the interface of any Derivative Software.
+ 2. to reproduce said notices, in an identical manner, in the copies of
+    the Software modified or not.
 
 The Licensee undertakes not to directly or indirectly infringe the
-intellectual property rights of the Holder and/or Contributors on the
-Software and to take, where applicable, vis-à-vis its staff, any and all
-measures required to ensure respect of said intellectual property rights
-of the Holder and/or Contributors.
+intellectual property rights on the Software of the Holder and/or
+Contributors, and to take, where applicable, vis-à-vis its staff, any
+and all measures required to ensure respect of said intellectual
+property rights of the Holder and/or Contributors.
 
 
     Article 7 - RELATED SERVICES
@@ -401,13 +404,13 @@ or properties.
 
 9.2 The Licensor hereby represents, in good faith, that it is entitled
 to grant all the rights over the Software (including in particular the
-rights set forth in Article 5).
+rights set forth in Article 5 <#scope>).
 
 9.3 The Licensee acknowledges that the Software is supplied "as is" by
 the Licensor without any other express or tacit warranty, other than
-that provided for in Article 9.2 and, in particular, without any warranty
-as to its commercial value, its secured, safe, innovative or relevant
-nature.
+that provided for in Article 9.2 <#good-faith> and, in particular,
+without any warranty as to its commercial value, its secured, safe,
+innovative or relevant nature.
 
 Specifically, the Licensor does not warrant that the Software is free
 from any error, that it will operate without interruption, that it will
@@ -422,7 +425,7 @@ arising out of any or all proceedings for infringement that may be
 instituted in respect of the use, modification and redistribution of the
 Software. Nevertheless, should such proceedings be instituted against
 the Licensee, the Licensor shall provide it with technical and legal
-assistance for its defense. Such technical and legal assistance shall be
+expertise for its defense. Such technical and legal expertise shall be
 decided on a case-by-case basis between the relevant Licensor and the
 Licensee pursuant to a memorandum of understanding. The Licensor
 disclaims any and all liability as regards the Licensee's use of the
@@ -499,7 +502,8 @@ address new issues encountered by Free Software.
 
 12.3 Any Software distributed under a given version of the Agreement may
 only be subsequently distributed under the same version of the Agreement
-or a subsequent version.
+or a subsequent version, subject to the provisions of Article 5.3.4
+<#compatibility>.
 
 
     Article 13 - GOVERNING LAW AND JURISDICTION
@@ -513,5 +517,3 @@ occurrence, and unless emergency proceedings are necessary, the
 disagreements or disputes shall be referred to the Paris Courts having
 jurisdiction, by the more diligent Party.
 
-
-Version 1.0 dated 2006-09-05.

--- a/Licence_CeCILL_V2.1-fr.txt
+++ b/Licence_CeCILL_V2.1-fr.txt
@@ -1,5 +1,7 @@
 
-CONTRAT DE LICENCE DE LOGICIEL LIBRE CeCILL-C
+  CONTRAT DE LICENCE DE LOGICIEL LIBRE CeCILL
+
+Version 2.1 du 2013-06-21
 
 
     Avertissement
@@ -8,28 +10,28 @@ Ce contrat est une licence de logiciel libre issue d'une concertation
 entre ses auteurs afin que le respect de deux grands principes préside à
 sa rédaction:
 
-    * d'une part, le respect des principes de diffusion des logiciels
-      libres: accès au code source, droits étendus conférés aux
-      utilisateurs,
-    * d'autre part, la désignation d'un droit applicable, le droit
-      français, auquel elle est conforme, tant au regard du droit de la
-      responsabilité civile que du droit de la propriété intellectuelle
-      et de la protection qu'il offre aux auteurs et titulaires des
-      droits patrimoniaux sur un logiciel.
+  * d'une part, le respect des principes de diffusion des logiciels
+    libres: accès au code source, droits étendus conférés aux utilisateurs,
+  * d'autre part, la désignation d'un droit applicable, le droit
+    français, auquel elle est conforme, tant au regard du droit de la
+    responsabilité civile que du droit de la propriété intellectuelle et
+    de la protection qu'il offre aux auteurs et titulaires des droits
+    patrimoniaux sur un logiciel.
 
-Les auteurs de la licence CeCILL-C (pour Ce[a] C[nrs] I[nria] L[ogiciel]
-L[ibre]) sont:
+Les auteurs de la licence CeCILL (Ce[a] C[nrs] I[nria] L[ogiciel] L[ibre])
+sont:
 
-Commissariat à l'Energie Atomique - CEA, établissement public de
-recherche à caractère scientifique, technique et industriel, dont le
-siège est situé 25 rue Leblanc, immeuble Le Ponant D, 75015 Paris.
+Commissariat à l'énergie atomique et aux énergies alternatives - CEA,
+établissement public de recherche à caractère scientifique, technique et
+industriel, dont le siège est situé 25 rue Leblanc, immeuble Le Ponant
+D, 75015 Paris.
 
 Centre National de la Recherche Scientifique - CNRS, établissement
 public à caractère scientifique et technologique, dont le siège est
 situé 3 rue Michel-Ange, 75794 Paris cedex 16.
 
 Institut National de Recherche en Informatique et en Automatique -
-INRIA, établissement public à caractère scientifique et technologique,
+Inria, établissement public à caractère scientifique et technologique,
 dont le siège est situé Domaine de Voluceau, Rocquencourt, BP 105, 78153
 Le Chesnay cedex.
 
@@ -37,18 +39,19 @@ Le Chesnay cedex.
     Préambule
 
 Ce contrat est une licence de logiciel libre dont l'objectif est de
-conférer aux utilisateurs la liberté de modifier et de réutiliser le
-logiciel régi par cette licence.
+conférer aux utilisateurs la liberté de modification et de
+redistribution du logiciel régi par cette licence dans le cadre d'un
+modèle de diffusion en logiciel libre.
 
-L'exercice de cette liberté est assorti d'une obligation de remettre à
-la disposition de la communauté les modifications apportées au code
-source du logiciel afin de contribuer à son évolution.
+L'exercice de ces libertés est assorti de certains devoirs à la charge
+des utilisateurs afin de préserver ce statut au cours des
+redistributions ultérieures.
 
 L'accessibilité au code source et les droits de copie, de modification
-et de redistribution qui découlent de ce contrat ont pour contrepartie
-de n'offrir aux utilisateurs qu'une garantie limitée et de ne faire
-peser sur l'auteur du logiciel, le titulaire des droits patrimoniaux et
-les concédants successifs qu'une responsabilité restreinte.
+et de redistribution qui en découlent ont pour contrepartie de n'offrir
+aux utilisateurs qu'une garantie limitée et de ne faire peser sur
+l'auteur du logiciel, le titulaire des droits patrimoniaux et les
+concédants successifs qu'une responsabilité restreinte.
 
 A cet égard l'attention de l'utilisateur est attirée sur les risques
 associés au chargement, à l'utilisation, à la modification et/ou au
@@ -66,6 +69,11 @@ réserve de le conserver en l'état, sans ajout ni suppression de clauses.
 Ce contrat est susceptible de s'appliquer à tout logiciel dont le
 titulaire des droits patrimoniaux décide de soumettre l'exploitation aux
 dispositions qu'il contient.
+
+Une liste de questions fréquemment posées se trouve sur le site web
+officiel de la famille des licences CeCILL 
+(http://www.cecill.info/index.fr.html) pour toute clarification qui
+serait nécessaire.
 
 
     Article 1 - DEFINITIONS
@@ -85,7 +93,7 @@ Logiciel Initial: désigne le Logiciel sous sa forme de Code Source et
 leur état au moment de leur première diffusion sous les termes du Contrat.
 
 Logiciel Modifié: désigne le Logiciel modifié par au moins une
-Contribution Intégrée.
+Contribution.
 
 Code Source: désigne l'ensemble des instructions et des lignes de
 programme du Logiciel et auquel l'accès est nécessaire en vue de
@@ -100,23 +108,37 @@ sur le Logiciel Initial.
 Licencié: désigne le ou les utilisateurs du Logiciel ayant accepté le
 Contrat.
 
-Contributeur: désigne le Licencié auteur d'au moins une Contribution
-Intégrée.
+Contributeur: désigne le Licencié auteur d'au moins une Contribution.
 
 Concédant: désigne le Titulaire ou toute personne physique ou morale
 distribuant le Logiciel sous le Contrat.
 
-Contribution Intégrée: désigne l'ensemble des modifications,
-corrections, traductions, adaptations et/ou nouvelles fonctionnalités
-intégrées dans le Code Source par tout Contributeur.
+Contribution: désigne l'ensemble des modifications, corrections,
+traductions, adaptations et/ou nouvelles fonctionnalités intégrées dans
+le Logiciel par tout Contributeur, ainsi que tout Module Interne.
 
-Module Lié: désigne un ensemble de fichiers sources y compris leur
-documentation qui, sans modification du Code Source, permet de réaliser
-des fonctionnalités ou services supplémentaires à ceux fournis par le
-Logiciel.
+Module: désigne un ensemble de fichiers sources y compris leur
+documentation qui permet de réaliser des fonctionnalités ou services
+supplémentaires à ceux fournis par le Logiciel.
 
-Logiciel Dérivé: désigne toute combinaison du Logiciel, modifié ou non,
-et d'un Module Lié.
+Module Externe: désigne tout Module, non dérivé du Logiciel, tel que ce
+Module et le Logiciel s'exécutent dans des espaces d'adressage
+différents, l'un appelant l'autre au moment de leur exécution.
+
+Module Interne: désigne tout Module lié au Logiciel de telle sorte
+qu'ils s'exécutent dans le même espace d'adressage.
+
+GNU GPL: désigne la GNU General Public License dans sa version 2 ou
+toute version ultérieure, telle que publiée par Free Software Foundation
+Inc.
+
+GNU Affero GPL: désigne la GNU Affero General Public License dans sa
+version 3 ou toute version ultérieure, telle que publiée par Free
+Software Foundation Inc.
+
+EUPL: désigne la Licence Publique de l'Union européenne dans sa version
+1.1 ou toute version ultérieure, telle que publiée par la Commission
+Européenne.
 
 Parties: désigne collectivement le Licencié et le Concédant.
 
@@ -127,8 +149,8 @@ Ces termes s'entendent au singulier comme au pluriel.
 
 Le Contrat a pour objet la concession par le Concédant au Licencié d'une
 licence non exclusive, cessible et mondiale du Logiciel telle que
-définie ci-après à l'article 5 pour toute la durée de protection des droits
-portant sur ce Logiciel.
+définie ci-après à l'article 5 <#etendue> pour toute la durée de
+protection des droits portant sur ce Logiciel.
 
 
     Article 3 - ACCEPTATION
@@ -136,18 +158,18 @@ portant sur ce Logiciel.
 3.1 L'acceptation par le Licencié des termes du Contrat est réputée
 acquise du fait du premier des faits suivants:
 
-    * (i) le chargement du Logiciel par tout moyen notamment par
-      téléchargement à partir d'un serveur distant ou par chargement à
-      partir d'un support physique;
-    * (ii) le premier exercice par le Licencié de l'un quelconque des
-      droits concédés par le Contrat.
+  * (i) le chargement du Logiciel par tout moyen notamment par
+    téléchargement à partir d'un serveur distant ou par chargement à
+    partir d'un support physique;
+  * (ii) le premier exercice par le Licencié de l'un quelconque des
+    droits concédés par le Contrat.
 
 3.2 Un exemplaire du Contrat, contenant notamment un avertissement
 relatif aux spécificités du Logiciel, à la restriction de garantie et à
 la limitation à un usage par des utilisateurs expérimentés a été mis à
 disposition du Licencié préalablement à son acceptation telle que
-définie à l'article 3.1 ci dessus et le Licencié reconnaît en avoir pris
-connaissance.
+définie à l'article 3.1 <#acceptation-acquise> ci dessus et le Licencié
+reconnaît en avoir pris connaissance.
 
 
     Article 4 - ENTREE EN VIGUEUR ET DUREE
@@ -156,7 +178,7 @@ connaissance.
       4.1 ENTREE EN VIGUEUR
 
 Le Contrat entre en vigueur à la date de son acceptation par le Licencié
-telle que définie en 3.1.
+telle que définie en 3.1 <#acceptation-acquise>.
 
 
       4.2 DUREE
@@ -185,30 +207,35 @@ faire reprendre les obligations du présent alinéa aux cessionnaires.
 Le Licencié est autorisé à utiliser le Logiciel, sans restriction quant
 aux domaines d'application, étant ci-après précisé que cela comporte:
 
-   1. la reproduction permanente ou provisoire du Logiciel en tout ou
-      partie par tout moyen et sous toute forme.
+ 1.
 
-   2. le chargement, l'affichage, l'exécution, ou le stockage du
-      Logiciel sur tout support.
+    la reproduction permanente ou provisoire du Logiciel en tout ou
+    partie par tout moyen et sous toute forme.
 
-   3. la possibilité d'en observer, d'en étudier, ou d'en tester le
-      fonctionnement afin de déterminer les idées et principes qui sont
-      à la base de n'importe quel élément de ce Logiciel; et ceci,
-      lorsque le Licencié effectue toute opération de chargement,
-      d'affichage, d'exécution, de transmission ou de stockage du
-      Logiciel qu'il est en droit d'effectuer en vertu du Contrat.
+ 2.
+
+    le chargement, l'affichage, l'exécution, ou le stockage du Logiciel
+    sur tout support.
+
+ 3.
+
+    la possibilité d'en observer, d'en étudier, ou d'en tester le
+    fonctionnement afin de déterminer les idées et principes qui sont à
+    la base de n'importe quel élément de ce Logiciel; et ceci, lorsque
+    le Licencié effectue toute opération de chargement, d'affichage,
+    d'exécution, de transmission ou de stockage du Logiciel qu'il est en
+    droit d'effectuer en vertu du Contrat.
 
 
-      5.2 DROIT DE MODIFICATION
+      5.2 DROIT D'APPORTER DES CONTRIBUTIONS
 
-Le droit de modification comporte le droit de traduire, d'adapter,
-d'arranger ou d'apporter toute autre modification au Logiciel et le
-droit de reproduire le logiciel en résultant. Il comprend en particulier
-le droit de créer un Logiciel Dérivé.
+Le droit d'apporter des Contributions comporte le droit de traduire,
+d'adapter, d'arranger ou d'apporter toute autre modification au Logiciel
+et le droit de reproduire le logiciel en résultant.
 
-Le Licencié est autorisé à apporter toute modification au Logiciel sous
+Le Licencié est autorisé à apporter toute Contribution au Logiciel sous
 réserve de mentionner, de façon explicite, son nom en tant qu'auteur de
-cette modification et la date de création de celle-ci.
+cette Contribution et la date de création de celle-ci.
 
 
       5.3 DROIT DE DISTRIBUTION
@@ -229,71 +256,73 @@ sous forme de Code Source ou de Code Objet, à condition que cette
 distribution respecte les dispositions du Contrat dans leur totalité et
 soit accompagnée:
 
-   1. d'un exemplaire du Contrat,
+ 1.
 
-   2. d'un avertissement relatif à la restriction de garantie et de
-      responsabilité du Concédant telle que prévue aux articles 8
-      et 9,
+    d'un exemplaire du Contrat,
+
+ 2.
+
+    d'un avertissement relatif à la restriction de garantie et de
+    responsabilité du Concédant telle que prévue aux articles 8
+    <#responsabilite> et 9 <#garantie>,
 
 et que, dans le cas où seul le Code Objet du Logiciel est redistribué,
 le Licencié permette un accès effectif au Code Source complet du
-Logiciel pendant au moins toute la durée de sa distribution du Logiciel,
-étant entendu que le coût additionnel d'acquisition du Code Source ne
-devra pas excéder le simple coût de transfert des données.
+Logiciel pour une durée d'au moins 3 ans à compter de la distribution du
+logiciel, étant entendu que le coût additionnel d'acquisition du Code
+Source ne devra pas excéder le simple coût de transfert des données.
 
 
         5.3.2 DISTRIBUTION DU LOGICIEL MODIFIE
 
-Lorsque le Licencié apporte une Contribution Intégrée au Logiciel, les
-conditions de distribution du Logiciel Modifié en résultant sont alors
-soumises à l'intégralité des dispositions du Contrat.
+Lorsque le Licencié apporte une Contribution au Logiciel, les conditions
+de distribution du Logiciel Modifié en résultant sont alors soumises à
+l'intégralité des dispositions du Contrat.
 
-Le Licencié est autorisé à distribuer le Logiciel Modifié sous forme de
+Le Licencié est autorisé à distribuer le Logiciel Modifié, sous forme de
 code source ou de code objet, à condition que cette distribution
 respecte les dispositions du Contrat dans leur totalité et soit
 accompagnée:
 
-   1. d'un exemplaire du Contrat,
+ 1.
 
-   2. d'un avertissement relatif à la restriction de garantie et de
-      responsabilité du Concédant telle que prévue aux articles 8
-      et 9,
+    d'un exemplaire du Contrat,
 
-et que, dans le cas où seul le code objet du Logiciel Modifié est
-redistribué, le Licencié permette un accès effectif à son code source
-complet pendant au moins toute la durée de sa distribution du Logiciel
-Modifié, étant entendu que le coût additionnel d'acquisition du code
-source ne devra pas excéder le simple coût de transfert des données.
+ 2.
 
+    d'un avertissement relatif à la restriction de garantie et de
+    responsabilité du Concédant telle que prévue aux articles 8
+    <#responsabilite> et 9 <#garantie>,
 
-        5.3.3 DISTRIBUTION DU LOGICIEL DERIVE
+et, dans le cas où seul le code objet du Logiciel Modifié est redistribué,
 
-Lorsque le Licencié crée un Logiciel Dérivé, ce Logiciel Dérivé peut
-être distribué sous un contrat de licence autre que le présent Contrat à
-condition de respecter les obligations de mention des droits sur le
-Logiciel telles que définies à l'article 6.4. Dans le cas où la création du
-Logiciel Dérivé a nécessité une modification du Code Source le licencié
-s'engage à ce que: 
+ 3.
 
-   1. le Logiciel Modifié correspondant à cette modification soit régi
-      par le présent Contrat,
-   2. les Contributions Intégrées dont le Logiciel Modifié résulte
-      soient clairement identifiées et documentées,
-   3. le Licencié permette un accès effectif au code source du Logiciel
-      Modifié, pendant au moins toute la durée de la distribution du
-      Logiciel Dérivé, de telle sorte que ces modifications puissent
-      être reprises dans une version ultérieure du Logiciel, étant
-      entendu que le coût additionnel d'acquisition du code source du
-      Logiciel Modifié ne devra pas excéder le simple coût du transfert
-      des données.
+    d'une note précisant les conditions d'accès effectif au code source
+    complet du Logiciel Modifié, pendant une période d'au moins 3 ans à
+    compter de la distribution du Logiciel Modifié, étant entendu que le
+    coût additionnel d'acquisition du code source ne devra pas excéder
+    le simple coût de transfert des données.
 
 
-        5.3.4 COMPATIBILITE AVEC LA LICENCE CeCILL
+        5.3.3 DISTRIBUTION DES MODULES EXTERNES
 
-Lorsqu'un Logiciel Modifié contient une Contribution Intégrée soumise au
-contrat de licence CeCILL, ou lorsqu'un Logiciel Dérivé contient un
-Module Lié soumis au contrat de licence CeCILL, les stipulations prévues
-au troisième item de l'article 6.4 sont facultatives.
+Lorsque le Licencié a développé un Module Externe les conditions du
+Contrat ne s'appliquent pas à ce Module Externe, qui peut être distribué
+sous un contrat de licence différent.
+
+
+        5.3.4 COMPATIBILITE AVEC D'AUTRES LICENCES
+
+Le Licencié peut inclure un code soumis aux dispositions d'une des
+versions de la licence GNU GPL, GNU Affero GPL et/ou EUPL dans le
+Logiciel modifié ou non et distribuer l'ensemble sous les conditions de
+la même version de la licence GNU GPL, GNU Affero GPL et/ou EUPL.
+
+Le Licencié peut inclure le Logiciel modifié ou non dans un code soumis
+aux dispositions d'une des versions de la licence GNU GPL, GNU Affero
+GPL et/ou EUPL et distribuer l'ensemble sous les conditions de la même
+version de la licence GNU GPL, GNU Affero GPL et/ou EUPL.
 
 
     Article 6 - PROPRIETE INTELLECTUELLE
@@ -308,38 +337,37 @@ oeuvre et nul autre n'a la faculté de modifier les conditions de
 diffusion de ce Logiciel Initial.
 
 Le Titulaire s'engage à ce que le Logiciel Initial reste au moins régi
-par le Contrat et ce, pour la durée visée à l'article 4.2.
+par le Contrat et ce, pour la durée visée à l'article 4.2 <#duree>.
 
 
-      6.2 SUR LES CONTRIBUTIONS INTEGREES
+      6.2 SUR LES CONTRIBUTIONS
 
-Le Licencié qui a développé une Contribution Intégrée est titulaire sur
-celle-ci des droits de propriété intellectuelle dans les conditions
-définies par la législation applicable.
-
-
-      6.3 SUR LES MODULES LIES
-
-Le Licencié qui a développé un Module Lié est titulaire sur celui-ci des
-droits de propriété intellectuelle dans les conditions définies par la
-législation applicable et reste libre du choix du contrat régissant sa
-diffusion dans les conditions définies à l'article 5.3.3.
+Le Licencié qui a développé une Contribution est titulaire sur celle-ci
+des droits de propriété intellectuelle dans les conditions définies par
+la législation applicable.
 
 
-      6.4 MENTIONS DES DROITS
+      6.3 SUR LES MODULES EXTERNES
+
+Le Licencié qui a développé un Module Externe est titulaire sur celui-ci
+des droits de propriété intellectuelle dans les conditions définies par
+la législation applicable et reste libre du choix du contrat régissant
+sa diffusion.
+
+
+      6.4 DISPOSITIONS COMMUNES
 
 Le Licencié s'engage expressément:
 
-   1. à ne pas supprimer ou modifier de quelque manière que ce soit les
-      mentions de propriété intellectuelle apposées sur le Logiciel;
+ 1.
 
-   2. à reproduire à l'identique lesdites mentions de propriété
-      intellectuelle sur les copies du Logiciel modifié ou non;
+    à ne pas supprimer ou modifier de quelque manière que ce soit les
+    mentions de propriété intellectuelle apposées sur le Logiciel;
 
-   3. à faire en sorte que l'utilisation du Logiciel, ses mentions de
-      propriété intellectuelle et le fait qu'il est régi par le Contrat
-      soient indiqués dans un texte facilement accessible notamment
-      depuis l'interface de tout Logiciel Dérivé.
+ 2.
+
+    à reproduire à l'identique lesdites mentions de propriété
+    intellectuelle sur les copies du Logiciel modifié ou non.
 
 Le Licencié s'engage à ne pas porter atteinte, directement ou
 indirectement, aux droits de propriété intellectuelle du Titulaire et/ou
@@ -370,10 +398,11 @@ Concédant et le Licencié.
 
     Article 8 - RESPONSABILITE
 
-8.1 Sous réserve des dispositions de l'article 8.2, le Licencié a la 
-faculté, sous réserve de prouver la faute du Concédant concerné, de
-solliciter la réparation du préjudice direct qu'il subirait du fait du
-Logiciel et dont il apportera la preuve.
+8.1 Sous réserve des dispositions de l'article 8.2
+<#limite-responsabilite>, le Licencié a la faculté, sous réserve de
+prouver la faute du Concédant concerné, de solliciter la réparation du
+préjudice direct qu'il subirait du fait du Logiciel et dont il apportera
+la preuve.
 
 8.2 La responsabilité du Concédant est limitée aux engagements pris en
 application du Contrat et ne saurait être engagée en raison notamment:
@@ -405,12 +434,12 @@ de s'assurer qu'il ne causera pas de dommages aux personnes et aux biens.
 
 9.2 Le Concédant déclare de bonne foi être en droit de concéder
 l'ensemble des droits attachés au Logiciel (comprenant notamment les
-droits visés à l'article 5).
+droits visés à l'article 5 <#etendue>).
 
 9.3 Le Licencié reconnaît que le Logiciel est fourni "en l'état" par le
 Concédant sans autre garantie, expresse ou tacite, que celle prévue à
-l'article 9.2 et notamment sans aucune garantie sur sa valeur commerciale,
-son caractère sécurisé, innovant ou pertinent.
+l'article 9.2 <#bonne-foi> et notamment sans aucune garantie sur sa
+valeur commerciale, son caractère sécurisé, innovant ou pertinent.
 
 En particulier, le Concédant ne garantit pas que le Logiciel est exempt
 d'erreur, qu'il fonctionnera sans interruption, qu'il sera compatible
@@ -424,8 +453,8 @@ autre droit de propriété. Ainsi, le Concédant exclut toute garantie au
 profit du Licencié contre les actions en contrefaçon qui pourraient être
 diligentées au titre de l'utilisation, de la modification, et de la
 redistribution du Logiciel. Néanmoins, si de telles actions sont
-exercées contre le Licencié, le Concédant lui apportera son aide
-technique et juridique pour sa défense. Cette aide technique et
+exercées contre le Licencié, le Concédant lui apportera son expertise
+technique et juridique pour sa défense. Cette expertise technique et
 juridique est déterminée au cas par cas entre le Concédant concerné et
 le Licencié dans le cadre d'un protocole d'accord. Le Concédant dégage
 toute responsabilité quant à l'utilisation de la dénomination du
@@ -503,7 +532,8 @@ compte de nouvelles problématiques rencontrées par les logiciels libres.
 
 12.3 Tout Logiciel diffusé sous une version donnée du Contrat ne pourra
 faire l'objet d'une diffusion ultérieure que sous la même version du
-Contrat ou une version postérieure.
+Contrat ou une version postérieure, sous réserve des dispositions de
+l'article 5.3.4 <#compatibilite>.
 
 
     Article 13 - LOI APPLICABLE ET COMPETENCE TERRITORIALE
@@ -518,4 +548,3 @@ les différends ou litiges seront portés par la Partie la plus diligente
 devant les Tribunaux compétents de Paris.
 
 
-Version 1.0 du 2006-09-05.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The corresponding reference list should be as follows:
 
 ## Copyright and license
 
-General copyright name and year is clearly stated at the top of each source file. All software released under [CeCILL-C version 1](Licence_CeCILL-C_V1-en.txt).
+General copyright name and year is clearly stated at the top of each source file. All software released under [CeCILL version 2.1](Licence_CeCILL_V2.1-en.txt).
 
 
 ## References

--- a/src/driver/abor1_sfx.F90
+++ b/src/driver/abor1_sfx.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #############################################################
       SUBROUTINE ABOR1_SFX(YTEXT)

--- a/src/driver/add_forecast_to_date_surf.F90
+++ b/src/driver/add_forecast_to_date_surf.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     ################################
       MODULE MODI_ADD_FORECAST_TO_DATE_SURF

--- a/src/driver/close_file.F90
+++ b/src/driver/close_file.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #########################
       MODULE MODI_CLOSE_FILE

--- a/src/driver/close_file_asc.F90
+++ b/src/driver/close_file_asc.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #############################
       MODULE MODI_CLOSE_FILE_ASC

--- a/src/driver/driver.F90
+++ b/src/driver/driver.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! ======================================================================
 PROGRAM DRIVER

--- a/src/driver/modd_arch.F90
+++ b/src/driver/modd_arch.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     ##################
       MODULE MODD_ARCH

--- a/src/driver/modd_forc_atm.F90
+++ b/src/driver/modd_forc_atm.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     ######################
 MODULE MODD_FORC_ATM

--- a/src/driver/modd_reprod_oper.F90
+++ b/src/driver/modd_reprod_oper.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ######################
       MODULE MODD_REPROD_OPER
 !     ######################

--- a/src/driver/modd_surf_conf.F90
+++ b/src/driver/modd_surf_conf.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #####################
       MODULE MODD_SURF_CONF

--- a/src/driver/modd_wrf_teb_driver.F90
+++ b/src/driver/modd_wrf_teb_driver.F90
@@ -1,5 +1,5 @@
 ! TEB version 4.0.0 (https://github.com/teb-model/teb).
-! Copyright 2018 D. Meyer. Licensed under CeCILL-C version 1.
+! Copyright 2018 D. Meyer. Licensed under CeCILL version 2.1.
 
 MODULE MODD_WRF_TEB_DRIVER
 

--- a/src/driver/mode_char2real.F90
+++ b/src/driver/mode_char2real.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODE_CHAR2REAL
 

--- a/src/driver/ol_alloc_atm.F90
+++ b/src/driver/ol_alloc_atm.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !   ############################
     MODULE MODI_OL_ALLOC_ATM

--- a/src/driver/ol_read_atm.F90
+++ b/src/driver/ol_read_atm.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_OL_READ_ATM
 INTERFACE

--- a/src/driver/ol_read_atm_ascii.F90
+++ b/src/driver/ol_read_atm_ascii.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_OL_READ_ATM_ASCII
 INTERFACE

--- a/src/driver/ol_time_interp_atm.F90
+++ b/src/driver/ol_time_interp_atm.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_OL_TIME_INTERP_ATM
 INTERFACE

--- a/src/driver/open_close_bin_asc_forc.F90
+++ b/src/driver/open_close_bin_asc_forc.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     ################################################################
       SUBROUTINE OPEN_CLOSE_BIN_ASC_FORC(HACTION,HFORCING,KNI,HACTION2)

--- a/src/driver/read_surf_atm.F90
+++ b/src/driver/read_surf_atm.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_READ_SURF_ATM
 INTERFACE

--- a/src/proxi_SVAT/garden.F90
+++ b/src/proxi_SVAT/garden.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #########
     SUBROUTINE GARDEN(HIMPLICIT_WIND, TPTIME, PTSUN, PPEW_A_COEF, PPEW_B_COEF,       &

--- a/src/proxi_SVAT/greenroof.F90
+++ b/src/proxi_SVAT/greenroof.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #########
     SUBROUTINE GREENROOF(HIMPLICIT_WIND, TPTIME, PTSUN, PPEW_A_COEF, PPEW_B_COEF,    &

--- a/src/proxi_SVAT/modi_garden.F90
+++ b/src/proxi_SVAT/modi_garden.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_GARDEN
 INTERFACE

--- a/src/proxi_SVAT/modi_greenroof.F90
+++ b/src/proxi_SVAT/modi_greenroof.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_GREENROOF
 INTERFACE

--- a/src/proxi_SVAT/modi_teb_veg_properties.F90
+++ b/src/proxi_SVAT/modi_teb_veg_properties.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_TEB_VEG_PROPERTIES
 INTERFACE

--- a/src/proxi_SVAT/teb_veg_properties.F90
+++ b/src/proxi_SVAT/teb_veg_properties.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     #########
       SUBROUTINE TEB_VEG_PROPERTIES(PDIR_SW, PSCA_SW, PSW_BANDS, KSW,      &

--- a/src/solar/circumsolar_rad.F90
+++ b/src/solar/circumsolar_rad.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 MODULE MODI_CIRCUMSOLAR_RAD
 INTERFACE

--- a/src/solar/sunpos.F90
+++ b/src/solar/sunpos.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !     ##################
       MODULE MODI_SUNPOS

--- a/src/struct/alloc_teb_struct.F90
+++ b/src/struct/alloc_teb_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE ALLOC_TEB_STRUCT(KROOF_LAYER,KROAD_LAYER,KWALL_LAYER,KFLOOR_LAYER,&
                                TOP,T,BOP,B,TPN,TIR,DMT                           )

--- a/src/struct/bem_morpho_struct.F90
+++ b/src/struct/bem_morpho_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !#####################################################################
 SUBROUTINE BEM_MORPHO_STRUCT(PBLD, PWALL_O_HOR, PBLD_HEIGHT, PFLOOR_HEIGHT,     &
                       PGR, PN_FLOOR, PWALL_O_BLD, PGLAZ_O_BLD, PMASS_O_BLD,     &

--- a/src/struct/dealloc_teb_struct.F90
+++ b/src/struct/dealloc_teb_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE DEALLOC_TEB_STRUCT(TOP,T,BOP,B,TPN,TIR,DMT)
 !   ##########################################################################

--- a/src/struct/modd_bem_optionn.F90
+++ b/src/struct/modd_bem_optionn.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ################
       MODULE MODD_BEM_OPTION_n
 !     ################

--- a/src/struct/modd_bemn.F90
+++ b/src/struct/modd_bemn.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ################
       MODULE MODD_BEM_n
 !     ################

--- a/src/struct/modd_diag_misc_tebn.F90
+++ b/src/struct/modd_diag_misc_tebn.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ############################
       MODULE MODD_DIAG_MISC_TEB_n
 !     ############################

--- a/src/struct/modd_teb_irrign.F90
+++ b/src/struct/modd_teb_irrign.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ################
       MODULE MODD_TEB_IRRIG_n
 !     ################

--- a/src/struct/modd_teb_optionn.F90
+++ b/src/struct/modd_teb_optionn.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ################
       MODULE MODD_TEB_OPTION_n
 !     ################

--- a/src/struct/modd_teb_paneln.F90
+++ b/src/struct/modd_teb_paneln.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ################
       MODULE MODD_TEB_PANEL_n
 !     ################

--- a/src/struct/modd_tebn.F90
+++ b/src/struct/modd_tebn.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ################
       MODULE MODD_TEB_n
 !     ################

--- a/src/struct/modd_type_snow.F90
+++ b/src/struct/modd_type_snow.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #####################
       MODULE MODD_TYPE_SNOW
 !     #####################

--- a/src/struct/modi_alloc_teb_struct.F90
+++ b/src/struct/modi_alloc_teb_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 MODULE MODI_ALLOC_TEB_STRUCT
 !
 INTERFACE

--- a/src/struct/modi_dealloc_teb_struct.F90
+++ b/src/struct/modi_dealloc_teb_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 MODULE MODI_DEALLOC_TEB_STRUCT
 !
 INTERFACE

--- a/src/struct/modi_teb_garden_struct.f90
+++ b/src/struct/modi_teb_garden_struct.f90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
 MODULE MODI_TEB_GARDEN_STRUCT
 !

--- a/src/struct/teb_garden_struct.F90
+++ b/src/struct/teb_garden_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE TEB_GARDEN_STRUCT (OGARDEN, OGREENROOF, OSOLAR_PANEL,          &
                      HZ0H, HIMPLICIT_WIND, HROAD_DIR, HWALL_OPT, TPTIME,      &

--- a/src/struct/window_data_struct.F90
+++ b/src/struct/window_data_struct.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #############################################################
 SUBROUTINE WINDOW_DATA_STRUCT(KI,PSHGC, PU_WIN, PALB_WIN, PABS_WIN, PUGG_WIN, PTRAN_WIN)
 !     #############################################################

--- a/src/teb/avg_urban_fluxes.F90
+++ b/src/teb/avg_urban_fluxes.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE AVG_URBAN_FLUXES(TOP, T, B, TPN, DMT,                               &
                                 PTS_TWN, PEMIS_TWN,  PT_CAN,                       &

--- a/src/teb/bem.F90
+++ b/src/teb/bem.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
         SUBROUTINE BEM(BOP, T, B, DMT, PTSTEP, PSUNTIME, KDAY, PPS, PRHOA, PT_CAN,  &
                        PQ_CAN, PU_CAN, PHU_BLD, PT_RAD_IND, PFLX_BLD_FL, PFLX_BLD_MA,&

--- a/src/teb/bem_morpho.F90
+++ b/src/teb/bem_morpho.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !#####################################################################
 SUBROUTINE BEM_MORPHO(PBLD, PWALL_O_HOR, PBLD_HEIGHT, PWALL_O_BLD, B)
 !#####################################################################

--- a/src/teb/bld_e_budget.F90
+++ b/src/teb/bld_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE BLD_E_BUDGET( OTI_EVOL, PTSTEP, PBLD, PWALL_O_HOR,      &
                              PRHOA, PT_ROOF, PT_WALL, PTI_BLD, PTS_FLOOR )  

--- a/src/teb/bld_occ_calendar.F90
+++ b/src/teb/bld_occ_calendar.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !#####################################################################################
 SUBROUTINE BLD_OCC_CALENDAR(TPTIME, PTSUN, T, B, PQIN_FRAC, PTCOOL_TARGET, PTHEAT_TARGET, PQIN)
 !#####################################################################################

--- a/src/teb/day_of_week.F90
+++ b/src/teb/day_of_week.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !################################################
 SUBROUTINE DAY_OF_WEEK(PYEAR, PMONTH, PDAY, PDOW)
 !################################################

--- a/src/teb/dx_air_cooling_coil_cv.F90
+++ b/src/teb/dx_air_cooling_coil_cv.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 SUBROUTINE DX_AIR_COOLING_COIL_CV(PT_CANYON, PQ_CANYON, PPS, PRHOA,    &
                              PT_IN, PQ_IN, PCOP_RAT, PCAP_SYS_RAT,     &
                              PT_ADP, PF_WATER_COND,                    &

--- a/src/teb/facade_e_budget.F90
+++ b/src/teb/facade_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 SUBROUTINE FACADE_E_BUDGET(TOP, T, B, DMT, PTSTEP, PDN_RD, PRHOA, PAC_WL, PAC_BLD, &
                            PLW_RAD, PPS, PEXNS, PT_CANYON, PTS_RD, PTSN_RD, PTS_GD, &
                            PTS_FL, PLW_WA_TO_WB, PLW_R_TO_WA, PLW_R_TO_WB,          &

--- a/src/teb/floor_layer_e_budget.F90
+++ b/src/teb/floor_layer_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE FLOOR_LAYER_E_BUDGET(B, PTSTEP, PFLX_BLD_FL, PDQS_FL, PIMB_FL, PRADHT_IN,  &
                                     PRAD_WL_FL, PRAD_RF_FL, PRAD_WIN_FL, PLOAD_FL,        &

--- a/src/teb/hook.F90
+++ b/src/teb/hook.F90
@@ -1,10 +1,9 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Copyright 1998-2013 Meteo-France
-! This is part of the TEB software governed by the CeCILL-C licence version 1.
-! See LICENCE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt for details.
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.txt
-! http://www.cecill.info/licences/Licence_CeCILL-C_V1-fr.txt
-! The CeCILL-C licence is compatible with L-GPL
+! This is part of the TEB software governed by the CeCILL licence version 2.1.
+! See the following links for details:
+! https://cecill.info/licences/Licence_CeCILL_V2.1-en.txt
+! https://cecill.info/licences/Licence_CeCILL_V2.1-fr.txt
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !* The modules below are just proxi of a debugging code internal
 ! to Meteo-France and IFS softwares. These proxi have no use at all

--- a/src/teb/ini_csts.F90
+++ b/src/teb/ini_csts.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
       SUBROUTINE INI_CSTS 
 !     ##################

--- a/src/teb/layer_e_budget.F90
+++ b/src/teb/layer_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE LAYER_E_BUDGET( PT, PTSTEP, PIMPL, PHC, PTC, PD, PA, PB, PC, PY, PDQS )
 !   ##########################################################################

--- a/src/teb/layer_e_budget_get_coef.F90
+++ b/src/teb/layer_e_budget_get_coef.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE LAYER_E_BUDGET_GET_COEF(PT, PTSTEP, PIMPL, PHC, PTC, PD, PA, PB, PC, PY)
 !   ##########################################################################

--- a/src/teb/mass_layer_e_budget.F90
+++ b/src/teb/mass_layer_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE MASS_LAYER_E_BUDGET(B, PTSTEP, PFLX_BLD_MA, PDQS_MA, PIMB_MA, PRADHT_IN, &
                                    PRAD_WL_MA, PRAD_RF_MA, PRAD_WIN_MA, PLOAD_MA,       &

--- a/src/teb/modd_bem_cst.F90
+++ b/src/teb/modd_bem_cst.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ###############
       MODULE MODD_BEM_CST      
 !     ###############

--- a/src/teb/modd_csts.F90
+++ b/src/teb/modd_csts.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ###############
       MODULE MODD_CSTS      
 !     ###############

--- a/src/teb/modd_flood_par.F90
+++ b/src/teb/modd_flood_par.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ######################
       MODULE MODD_FLOOD_PAR
 !     ######################

--- a/src/teb/modd_snow_par.F90
+++ b/src/teb/modd_snow_par.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ######################
       MODULE MODD_SNOW_PAR
 !     ######################

--- a/src/teb/modd_surf_atm.F90
+++ b/src/teb/modd_surf_atm.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ####################
       MODULE MODD_SURF_ATM
 !     ####################

--- a/src/teb/modd_surf_par.F90
+++ b/src/teb/modd_surf_par.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !####################
 MODULE MODD_SURF_PAR
 !####################

--- a/src/teb/modd_type_date_surf.F90
+++ b/src/teb/modd_type_date_surf.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #################
       MODULE MODD_TYPE_DATE_SURF
 !     #################

--- a/src/teb/modd_water_par.F90
+++ b/src/teb/modd_water_par.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ######################
       MODULE MODD_WATER_PAR
 !     ######################

--- a/src/teb/mode_conv_DOE.F90
+++ b/src/teb/mode_conv_DOE.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !###################
 MODULE MODE_CONV_DOE
 !###################

--- a/src/teb/mode_psychro.F90
+++ b/src/teb/mode_psychro.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !##################
 MODULE MODE_PSYCHRO
 !##################

--- a/src/teb/mode_surf_snow_frac.F90
+++ b/src/teb/mode_surf_snow_frac.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ##########################
       MODULE MODE_SURF_SNOW_FRAC
 !     ##########################

--- a/src/teb/mode_thermos.F90
+++ b/src/teb/mode_thermos.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ######spl
       MODULE MODE_THERMOS
 !     ####################

--- a/src/teb/road_layer_e_budget.F90
+++ b/src/teb/road_layer_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE ROAD_LAYER_E_BUDGET(T, B, PTSTEP, PDN_ROAD, PRHOA, PAC_ROAD, PAC_ROAD_WAT, &
                                    PLW_RAD, PPS, PQSAT_ROAD, PDELT_ROAD, PEXNS,           &

--- a/src/teb/roof_impl_coef.F90
+++ b/src/teb/roof_impl_coef.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ###############################################
 SUBROUTINE ROOF_IMPL_COEF(T, PTSTEP, PTDEEP_A, PTDEEP_B)
 !   ###############################################

--- a/src/teb/roof_layer_e_budget.F90
+++ b/src/teb/roof_layer_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE ROOF_LAYER_E_BUDGET(TOP, T, B, PQSAT_ROOF, PAC_BLD, PTSTEP, PDN_ROOF,   &
                                    PRHOA, PAC_ROOF, PAC_ROOF_WAT, PLW_RAD, PPS,        &

--- a/src/teb/snow_cover_1layer.F90
+++ b/src/teb/snow_cover_1layer.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE SNOW_COVER_1LAYER(PTSTEP, PANSMIN, PANSMAX, PTODRY, PRHOSMIN, PRHOSMAX,   &
                                  PRHOFOLD, OALL_MELT, PDRAIN_TIME, PWCRN, PZ0SN, PZ0HSN, &

--- a/src/teb/solar_panel.F90
+++ b/src/teb/solar_panel.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE SOLAR_PANEL(TPN, DMT, PTSTEP, PTSUN, PRESIDENTIAL, PEMIT_LW_ROOF, &
                            PEMIT_LWDN_PANEL, PLW_RAD, PTA, PN_FLOOR, PPROD_BLD )

--- a/src/teb/surface_aero_cond.F90
+++ b/src/teb/surface_aero_cond.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ######################################################################
     SUBROUTINE SURFACE_AERO_COND(PRI, PZREF, PUREF, PVMOD, PZ0,&
                                      PZ0H, PAC, PRA, PCH           ) 

--- a/src/teb/surface_cd.F90
+++ b/src/teb/surface_cd.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   #################################################################
     SUBROUTINE SURFACE_CD(PRI, PZREF, PUREF, PZ0EFF, PZ0H,   &
                               PCD, PCDN) 

--- a/src/teb/surface_ri.F90
+++ b/src/teb/surface_ri.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE SURFACE_RI(PTG, PQS, PEXNS, PEXNA, PTA, PQA,   &
                                PZREF, PUREF, PDIRCOSZW, PVMOD, PRI )  

--- a/src/teb/teb.F90
+++ b/src/teb/teb.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE TEB  (TOP, T, BOP, B, TIR, DMT, HIMPLICIT_WIND, PTSUN,                   &
                      PT_CANYON, PQ_CANYON, PU_CANYON, PT_LOWCAN, PQ_LOWCAN, PU_LOWCAN,  &

--- a/src/teb/teb_garden.F90
+++ b/src/teb/teb_garden.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE TEB_GARDEN (TOP, T, BOP, B, TPN, TIR, DMT,                                         &
                            HIMPLICIT_WIND, PTSUN, PT_CAN, PQ_CAN, PU_CAN, PT_LOWCAN, PQ_LOWCAN,   &

--- a/src/teb/teb_irrig.F90
+++ b/src/teb/teb_irrig.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE TEB_IRRIG(OIRRIG, PTSTEP, KMONTH, PSOLAR_TIME,   &
                PSTART_MONTH, PEND_MONTH, PSTART_HOUR, PEND_HOUR,&

--- a/src/teb/tridiag_ground.F90
+++ b/src/teb/tridiag_ground.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
        SUBROUTINE TRIDIAG_GROUND(PA,PB,PC,PY,PX)
 !      #########################################

--- a/src/teb/urban_drag.F90
+++ b/src/teb/urban_drag.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE URBAN_DRAG(TOP, T, B, HIMPLICIT_WIND, PTSTEP, PT_CANYON, PQ_CANYON, &
                           PU_CANYON, PT_LOWCAN, PQ_LOWCAN, PU_LOWCAN, PZ_LOWCAN,   &

--- a/src/teb/urban_exch_coef.F90
+++ b/src/teb/urban_exch_coef.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
 SUBROUTINE URBAN_EXCH_COEF(HZ0H, PZ0_O_Z0H, PTG, PQS, PEXNS, PEXNA, PTA, PQA,   &
                              PZREF, PUREF, PVMOD, PZ0,                            &

--- a/src/teb/urban_fluxes.F90
+++ b/src/teb/urban_fluxes.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE URBAN_FLUXES(TOP, T, B, DMT, HIMPLICIT_WIND, PT_CANYON, PPEW_A_COEF, PPEW_B_COEF,      &
                             PEXNS, PRHOA, PVMOD, PH_TRAFFIC, PLE_TRAFFIC, PAC_WL, PCD, PDF_RF,        &

--- a/src/teb/urban_hydro.F90
+++ b/src/teb/urban_hydro.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE URBAN_HYDRO(PWS_ROOF_MAX,PWS_ROAD_MAX, PWS_ROOF, PWS_ROAD,  &
                              PRR, PIRRIG_ROAD, PTSTEP, PBLD, PLE_ROOF,     &

--- a/src/teb/urban_lw_coef.F90
+++ b/src/teb/urban_lw_coef.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE URBAN_LW_COEF(B, T, PLW_RAD, PEMIS_G, PTS_SR, PTS_G,              &  
                              PLW_WA_TO_WB, PLW_WA_TO_R, PLW_WB_TO_R,             &

--- a/src/teb/urban_snow_evol.F90
+++ b/src/teb/urban_snow_evol.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE URBAN_SNOW_EVOL(T, B, PT_LWCN, PQ_LWCN, PU_LWCN, PTS_RF, PTS_RD, PTS_WL_A,   &
                                PTS_WL_B, PPS, PTA, PQA, PRHOA, PLW_RAD, PSR, PZREF, PUREF,  &

--- a/src/teb/urban_solar_abs.F90
+++ b/src/teb/urban_solar_abs.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     SUBROUTINE URBAN_SOLAR_ABS(TOP, T, B, DMT, PDIR_SW, PSCA_SW, PZENITH, PAZIM,   &
                                PFRAC_PANEL, PALB_PANEL, PALB_GD, PSVF_GD, PALB_GRF, &

--- a/src/teb/wall_layer_e_budget.F90
+++ b/src/teb/wall_layer_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !   ##########################################################################
     SUBROUTINE WALL_LAYER_E_BUDGET(TOP, T, B, PT_WL, PTS_WL_B, PTI_WL_B, PTSTEP, PDN_RD,     &
                                    PRHOA, PAC_WL, PAC_BLD, PLW_RAD, PPS, PEXNS, PABS_SW_WL,  &

--- a/src/teb/wind_threshold.F90
+++ b/src/teb/wind_threshold.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #########
     FUNCTION WIND_THRESHOLD(PWIND,PUREF) RESULT(PWIND_NEW)
 !   ############################################################################

--- a/src/teb/window_data.F90
+++ b/src/teb/window_data.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #############################################################
 SUBROUTINE WINDOW_DATA(KI, B)
 !     #############################################################

--- a/src/teb/window_e_budget.F90
+++ b/src/teb/window_e_budget.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 SUBROUTINE WINDOW_E_BUDGET(B, PEMIS_WIN, PLW_W_TO_WIN, PLW_R_TO_WIN, PLW_G_TO_WIN, &
                            PLW_NR_TO_WIN, PLW_S_TO_WIN, PRAD_RF_WIN, PRAD_WL_WIN,  &
                            PABS_SW_WIN, PLW_RAD, PAC_WL, PRADHT_IN, PTS_FL, PRHOA, &

--- a/src/teb/window_shading.F90
+++ b/src/teb/window_shading.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     #############################################################
 SUBROUTINE WINDOW_SHADING(PSHGC, PSHGC_SH, O_SHADE, PALB_WALL,      &
                           PABS_WIN, PABS_WINSH, PALB_WIN, PTRAN_WIN )

--- a/src/teb/window_shading_availability.F90
+++ b/src/teb/window_shading_availability.F90
@@ -1,7 +1,7 @@
 !SFX_LIC Copyright 1994-2014 CNRS, Meteo-France and Universite Paul Sabatier
-!SFX_LIC This is part of the SURFEX software governed by the CeCILL-C licence
-!SFX_LIC version 1. See LICENSE, CeCILL-C_V1-en.txt and CeCILL-C_V1-fr.txt  
-!SFX_LIC for details. version 1.
+!SFX_LIC This is part of the SURFEX software governed by the CeCILL licence
+!SFX_LIC version 2.1. See Licence_CeCILL_V2.1-en.txt and Licence_CeCILL_V2.1-fr.txt  
+!SFX_LIC for details.
 !     ###########################################################################################################
       SUBROUTINE WINDOW_SHADING_AVAILABILITY(OSHADE, PTI_BLD, PTCOOL_TARGET,OSHADE_POSSIBLE)
 !     ###########################################################################################################

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,5 +1,5 @@
 # TEB version 4.0.0 (https://github.com/teb-model/teb).
-# Copyright 2018 D. Meyer. Licensed under CeCILL-C version 1.
+# Copyright 2018 D. Meyer. Licensed under CeCILL version 2.1.
 
 import sys
 import os

--- a/tools/common_names.py
+++ b/tools/common_names.py
@@ -1,5 +1,5 @@
 # TEB version 4.0.0 (https://github.com/teb-model/teb).
-# Copyright 2018 D. Meyer. Licensed under CeCILL-C version 1.
+# Copyright 2018 D. Meyer. Licensed under CeCILL version 2.1.
 
 standard_quantity_names = {
     "Atmospheric pressure": {

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,5 +1,5 @@
 # TEB version 4.0.0 (https://github.com/teb-model/teb).
-# Copyright 2018 D. Meyer. Licensed under CeCILL-C version 1.
+# Copyright 2018 D. Meyer. Licensed under CeCILL version 2.1.
 
 import os
 import subprocess


### PR DESCRIPTION
This PR updates the licence to CeCILL version 2.1 in header for source files and updates the two licence files at the root `Licence_CeCILL-C_V1-en.txt` to `Licence_CeCILL_V2.1-en.txt` and `Licence_CeCILL-C_V1-fr.txt` to `Licence_CeCILL_V2.1-fr.txt`.

@ValeryMasson  these are the licence changes about the licence we discussed, please could you check that they are all OK and approve if you agree so that I can merge it in `master`.