### PR TITLE
Change licence to MIT for all MC2 files

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -9,6 +9,7 @@ The original copyright notices and the licenses are included below:
 1.  dmey/minimal-dx version 0.1.1 (https://www.github.com/dmey/minimal-dx)
 2.  psychrometrics/psychrolib version 2.4.0 (https://github.com/psychrometrics/psychrolib)
 3.  NREL/EnergyPlusRelease version 8.1.0.009 (https://github.com/NREL/EnergyPlusRelease)
+4.  MC2 (Mesoscale Compressible Community) model
 
 %% dmey/minimal-dx NOTICES AND INFORMATION BEGIN HERE
 =========================================
@@ -112,3 +113,29 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED O
 POSSIBILITY OF SUCH DAMAGE.
 =========================================
 END OF NREL/EnergyPlusRelease NOTICES AND INFORMATION
+
+%% MC2 (Mesoscale Compressible Community) model NOTICES AND INFORMATION BEGIN HERE
+=========================================
+The MIT License (MIT)
+
+Copyright (c) 2018-2020 Environment Canada EC-RPN COMM Group.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+=========================================
+END OF MC2 (Mesoscale Compressible Community) model NOTICES AND INFORMATION

--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -118,7 +118,7 @@ END OF NREL/EnergyPlusRelease NOTICES AND INFORMATION
 =========================================
 The MIT License (MIT)
 
-Copyright (c) 2018-2020 Environment Canada EC-RPN COMM Group.
+Copyright (c) 2001-2020 Environment Canada EC-RPN COMM Group.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 pandas
-f90nml
+f90nml==1.1.2
 matplotlib

--- a/src/teb/consphy.cdk
+++ b/src/teb/consphy.cdk
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
       REAL CPD, CPV, RGASD, RGASV, TRPL, TCDK, RAUW, EPS1, EPS2

--- a/src/teb/consphy.cdk
+++ b/src/teb/consphy.cdk
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
       REAL CPD, CPV, RGASD, RGASV, TRPL, TCDK, RAUW, EPS1, EPS2
       REAL DELTA, CAPPA, TGL, CONSOL, GRAV, RAYT, STEFAN, PI
       REAL OMEGA

--- a/src/teb/consphy.fh
+++ b/src/teb/consphy.fh
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
       REAL CPD, CPV, RGASD, RGASV, TRPL, TCDK, RAUW, EPS1, EPS2

--- a/src/teb/consphy.fh
+++ b/src/teb/consphy.fh
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
       REAL CPD, CPV, RGASD, RGASV, TRPL, TCDK, RAUW, EPS1, EPS2
       REAL DELTA, CAPPA, TGL, CONSOL, GRAV, RAYT, STEFAN, PI
       REAL OMEGA

--- a/src/teb/flxsurf3bx.F
+++ b/src/teb/flxsurf3bx.F
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
 ***S/P  FLXSURF3

--- a/src/teb/flxsurf3bx.F
+++ b/src/teb/flxsurf3bx.F
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
 ***S/P  FLXSURF3
 *
       SUBROUTINE FLXSURF3BX(CMU, CTU, RIB, FTEMP, FVAP, ILMO,

--- a/src/teb/impnone.cdk
+++ b/src/teb/impnone.cdk
@@ -1,17 +1,5 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
       implicit none

--- a/src/teb/impnone.cdk
+++ b/src/teb/impnone.cdk
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
       implicit none

--- a/src/teb/impnone.fh
+++ b/src/teb/impnone.fh
@@ -1,17 +1,5 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
       implicit none

--- a/src/teb/impnone.fh
+++ b/src/teb/impnone.fh
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
       implicit none

--- a/src/teb/init_surfconsphy.F
+++ b/src/teb/init_surfconsphy.F
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
        SUBROUTINE INIT_SURFCONSPHY
 
 *     INITIALIZES THE CONSTANTS FOR THE COMMONS OF THE FLXSURF3 ROUTINE FROM

--- a/src/teb/init_surfconsphy.F
+++ b/src/teb/init_surfconsphy.F
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
        SUBROUTINE INIT_SURFCONSPHY

--- a/src/teb/modi_flxsurf3bx.f
+++ b/src/teb/modi_flxsurf3bx.f
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
 !     ######spl
       MODULE MODI_FLXSURF3BX
       INTERFACE

--- a/src/teb/modi_flxsurf3bx.f
+++ b/src/teb/modi_flxsurf3bx.f
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
 !     ######spl

--- a/src/teb/modi_init_surfconsphy.f
+++ b/src/teb/modi_init_surfconsphy.f
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
 !     ######spl

--- a/src/teb/modi_init_surfconsphy.f
+++ b/src/teb/modi_init_surfconsphy.f
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
 !     ######spl
       MODULE MODI_INIT_SURFCONSPHY
       INTERFACE

--- a/src/teb/stabfunc2.cdk
+++ b/src/teb/stabfunc2.cdk
@@ -1,5 +1,5 @@
 C MC2 (Mesoscale Compressible Community) model.
-C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 C Licensed under the MIT license.
 
 C   Internal function FMI

--- a/src/teb/stabfunc2.cdk
+++ b/src/teb/stabfunc2.cdk
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+C MC2 (Mesoscale Compressible Community) model.
+C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Licensed under the MIT license.
+
 C   Internal function FMI
 C   Stability function for momentum in the unstable regime (ilmo<0)
 c   Reference: Delage Y. and Girard C. BLM 58 (19-31) Eq. 19

--- a/src/teb/stabfunc2.fh
+++ b/src/teb/stabfunc2.fh
@@ -1,5 +1,5 @@
 C MC2 (Mesoscale Compressible Community) model.
-C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 C Licensed under the MIT license.
 
 C   Internal function FMI

--- a/src/teb/stabfunc2.fh
+++ b/src/teb/stabfunc2.fh
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+C MC2 (Mesoscale Compressible Community) model.
+C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Licensed under the MIT license.
+
 C   Internal function FMI
 C   Stability function for momentum in the unstable regime (ilmo<0)
 c   Reference: Delage Y. and Girard C. BLM 58 (19-31) Eq. 19

--- a/src/teb/surfcon.cdk
+++ b/src/teb/surfcon.cdk
@@ -1,5 +1,5 @@
 C MC2 (Mesoscale Compressible Community) model.
-C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 C Licensed under the MIT license.
 
       REAL AS,ASX,CI,BS,BETA,FACTN,HMIN,ANGMAX,RAC3

--- a/src/teb/surfcon.cdk
+++ b/src/teb/surfcon.cdk
@@ -1,18 +1,6 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+C MC2 (Mesoscale Compressible Community) model.
+C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Licensed under the MIT license.
+
       REAL AS,ASX,CI,BS,BETA,FACTN,HMIN,ANGMAX,RAC3
       COMMON / SURFCON / AS,ASX,CI,BS,BETA,FACTN,HMIN,ANGMAX,RAC3

--- a/src/teb/surfcon.fh
+++ b/src/teb/surfcon.fh
@@ -1,5 +1,5 @@
 C MC2 (Mesoscale Compressible Community) model.
-C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 C Licensed under the MIT license.
 
       REAL AS,ASX,CI,BS,BETA,FACTN,HMIN,ANGMAX,RAC3

--- a/src/teb/surfcon.fh
+++ b/src/teb/surfcon.fh
@@ -1,18 +1,6 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+C MC2 (Mesoscale Compressible Community) model.
+C Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+C Licensed under the MIT license.
+
       REAL AS,ASX,CI,BS,BETA,FACTN,HMIN,ANGMAX,RAC3
       COMMON / SURFCON / AS,ASX,CI,BS,BETA,FACTN,HMIN,ANGMAX,RAC3

--- a/src/teb/vslog.f
+++ b/src/teb/vslog.f
@@ -1,19 +1,7 @@
-!-------------------------------------- LICENCE BEGIN ------------------------------------
-!Environment Canada - Atmospheric Science and Technology License/Disclaimer, 
-!                     version 3; Last Modified: May 7, 2008.
-!This is free but copyrighted software; you can use/redistribute/modify it under the terms 
-!of the Environment Canada - Atmospheric Science and Technology License/Disclaimer 
-!version 3 or (at your option) any later version that should be found at: 
-!http://collaboration.cmc.ec.gc.ca/science/rpn.comm/license.html 
-!
-!This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
-!without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
-!See the above mentioned License/Disclaimer for more details.
-!You should have received a copy of the License/Disclaimer along with this software; 
-!if not, you can write to: EC-RPN COMM Group, 2121 TransCanada, suite 500, Dorval (Quebec), 
-!CANADA, H9P 1J3; or send e-mail to service.rpn@ec.gc.ca
-!-------------------------------------- LICENCE END --------------------------------------
-!copyright (C) 2001  MSC-RPN COMM  %%%RPNPHY%%%
+! MC2 (Mesoscale Compressible Community) model.
+! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Licensed under the MIT license.
+
       SUBROUTINE VSLOG(PA,PLOG,N)
 
 *   COMPUTES THE LOGARITHM

--- a/src/teb/vslog.f
+++ b/src/teb/vslog.f
@@ -1,5 +1,5 @@
 ! MC2 (Mesoscale Compressible Community) model.
-! Copyright (c) 2018-2020 Environment Canada (EC-RPN COMM Group).
+! Copyright (c) 2001-2020 Environment Canada (EC-RPN COMM Group).
 ! Licensed under the MIT license.
 
       SUBROUTINE VSLOG(PA,PLOG,N)


### PR DESCRIPTION
This PR changes the licence of MC2 (Mesoscale Compressible Community) model files to MIT.