### PR TITLE
Update default value for albedo in veg module

### DIFF
--- a/src/proxi_SVAT/proxi_svat_consts.F90
+++ b/src/proxi_SVAT/proxi_svat_consts.F90
@@ -1,8 +1,8 @@
 MODULE PROXI_SVAT_CONSTS
 IMPLICIT NONE
  
-REAL :: VEG_ALB = 0.15
-REAL :: VEG_EMIS = 0.98
+REAL :: VEG_ALB = 0.25 ! Default for grass 
+REAL :: VEG_EMIS = 0.98 ! Default for grass
 REAL :: GARDEN_BR = 0.25
 REAL :: GREENROOF_BR = 0.5
 


### PR DESCRIPTION
The default value for albedo used in simple proxy veg scheme is now 0.25 (grass).